### PR TITLE
Fix watchface versionLabel format

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -4,7 +4,7 @@
   "longName": "Tutorial-3-3",
   "companyName": "Pebble",
   "versionCode": 1,
-  "versionLabel": "1.0.0",
+  "versionLabel": "1.0",
   "watchapp": {
     "watchface": true
   },


### PR DESCRIPTION
Noticed that this example was using the old `versionLabel` format, so I fixed it.
